### PR TITLE
認証方式について記載を修正

### DIFF
--- a/README.md
+++ b/README.md
@@ -152,7 +152,7 @@ sshの場合、公開鍵と秘密鍵の作成とGitHubへの登録が必要に�
 公式ドキュメント: https://docs.github.com/en/authentication/connecting-to-github-with-ssh  
 
 httpsの場合、個人アクセストークンを発行して認証に用いる必要があります。  
-公式ドキュメント： [個人アクセストークンを使用する](https://docs.github.com/ja/authentication/keeping-your-account-and-data-secure/creating-a-personal-access-token)  
+公式ドキュメント： https://docs.github.com/ja/authentication/keeping-your-account-and-data-secure/creating-a-personal-access-token  
 
 また、こちらは任意課題ですが、`GitHub https`や`GiｔHub ssh`で調べてそれぞれの接続設定の違いを把握して対応しましょう。  
 

--- a/README.md
+++ b/README.md
@@ -135,9 +135,10 @@ GitHubのどのレポジトリにpushするかを設定します。
 GitHubのmainブランチにpushします。  
 `$ git push origin main -u`  
 <img width="500" alt="スクリーンショット 2022-05-07 12 37 12" src="https://user-images.githubusercontent.com/62045457/167236636-a97dc855-6ccb-4f5c-aba4-6be72cb8abc0.png">  
-※始めてGitHubにpushする人はパスワードの入力が求められるかと思います。また、GitHubはパスワード認証でなく個人アクセストークンによる認証を推奨しています。  
+※始めてGitHubにpushする人はパスワードの入力が求められるかと思いますが、GitHubではパスワード認証でなく個人アクセストークンを発行して認証に用いる必要があります。  
 参考： [個人アクセストークンを使用する](https://docs.github.com/ja/authentication/keeping-your-account-and-data-secure/creating-a-personal-access-token)  
-接続方式をhttpsでなくsshにするというのもいいです。`GitHub https`や`GiｔHub ssh`で調べてそれぞれの接続設定の違いを把握して対応しましょう。  
+git clone時のプロトコルをhttpsでなくsshにすると個人アクセストークンの利用は不要になります。`GitHub https`や`GiｔHub ssh`で調べてそれぞれの接続設定の違いを把握して対応しましょう。  
+認証方式については時が流れるにつれて変わっていくものですので、こちらのハンズオンを更新する必要があるとわかった場合にはぜひご連絡ください。  
 
 ※mainブランチのブランチという考え方はぜひ自習してみてください。講義のなかでもまたご紹介します。  
 ※初回以降は`git push`でpushできます。  

--- a/README.md
+++ b/README.md
@@ -135,7 +135,7 @@ GitHubのどのレポジトリにpushするかを設定します。
 GitHubのmainブランチにpushします。  
 `$ git push origin main -u`  
 <img width="500" alt="スクリーンショット 2022-05-07 12 37 12" src="https://user-images.githubusercontent.com/62045457/167236636-a97dc855-6ccb-4f5c-aba4-6be72cb8abc0.png">  
-※始めてGitHubにpushする人は認証が必要になります。 
+※はじめてGitHubにpushする人は認証が必要になります。 
 認証方法はpush時に用いる通信方式がhttpsかsshかによって変わります。  
 
 リモートブランチを下記コマンドで確認することができます。  

--- a/README.md
+++ b/README.md
@@ -135,10 +135,26 @@ GitHubのどのレポジトリにpushするかを設定します。
 GitHubのmainブランチにpushします。  
 `$ git push origin main -u`  
 <img width="500" alt="スクリーンショット 2022-05-07 12 37 12" src="https://user-images.githubusercontent.com/62045457/167236636-a97dc855-6ccb-4f5c-aba4-6be72cb8abc0.png">  
-※始めてGitHubにpushする人はパスワードの入力が求められるかと思いますが、GitHubではパスワード認証でなく個人アクセストークンを発行して認証に用いる必要があります。  
-参考： [個人アクセストークンを使用する](https://docs.github.com/ja/authentication/keeping-your-account-and-data-secure/creating-a-personal-access-token)  
-git clone時のプロトコルをhttpsでなくsshにすると個人アクセストークンの利用は不要になります。`GitHub https`や`GiｔHub ssh`で調べてそれぞれの接続設定の違いを把握して対応しましょう。  
-認証方式については時が流れるにつれて変わっていくものですので、こちらのハンズオンを更新する必要があるとわかった場合にはぜひご連絡ください。  
+※始めてGitHubにpushする人は認証が必要になります。 
+認証方法はpush時に用いる通信方式がhttpsかsshかによって変わります。  
+
+リモートブランチを下記コマンドで確認することができます。  
+`$ git remote -v`  
+
+sshの場合: `https://github.com/raisetech-for-student/git-hands-on.git`  
+
+httpsの場合: `git@github.com:raisetech-for-student/git-hands-on.git`  
+
+※このハンズオンの手順をそのまま実施していればssh方式になります。  
+
+sshの場合、公開鍵と秘密鍵の作成とGitHubへの登録が必要になります。  
+`ssh GitHub`で調べるとやり方がでてきます。  
+公式ドキュメント: https://docs.github.com/en/authentication/connecting-to-github-with-ssh  
+
+httpsの場合、個人アクセストークンを発行して認証に用いる必要があります。  
+公式ドキュメント： [個人アクセストークンを使用する](https://docs.github.com/ja/authentication/keeping-your-account-and-data-secure/creating-a-personal-access-token)  
+
+また、こちらは任意課題ですが、`GitHub https`や`GiｔHub ssh`で調べてそれぞれの接続設定の違いを把握して対応しましょう。  
 
 ※mainブランチのブランチという考え方はぜひ自習してみてください。講義のなかでもまたご紹介します。  
 ※初回以降は`git push`でpushできます。  


### PR DESCRIPTION
# 概要

https時の認証方式についてパスワードでなくPATによる認証が必須である。
記載に誤解を生む表現があっため修正

また、ssh/httpsで認証方式が異なることも言及